### PR TITLE
FirebaseにFBプロフィールを登録する処理

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,6 +26,7 @@ variable_name:
     - vc
     - ad
     - Ad
+    - e
 
 type_name:
   excluded:

--- a/OASIS.xcodeproj/project.pbxproj
+++ b/OASIS.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		5AF25D221DCA2BE900CA07F8 /* ErrorHandlable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF25D211DCA2BE900CA07F8 /* ErrorHandlable.swift */; };
 		5AF25D241DCA2C0300CA07F8 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF25D231DCA2C0300CA07F8 /* String+.swift */; };
 		5AF25D261DCA314C00CA07F8 /* NSObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF25D251DCA314C00CA07F8 /* NSObject+.swift */; };
+		D12FFCE11DCB5490001B272F /* FBProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12FFCE01DCB5490001B272F /* FBProfile.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -88,6 +89,7 @@
 		5AF25D211DCA2BE900CA07F8 /* ErrorHandlable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandlable.swift; sourceTree = "<group>"; };
 		5AF25D231DCA2C0300CA07F8 /* String+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		5AF25D251DCA314C00CA07F8 /* NSObject+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+.swift"; sourceTree = "<group>"; };
+		D12FFCE01DCB5490001B272F /* FBProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FBProfile.swift; sourceTree = "<group>"; };
 		E4C0CC7AACB26DAC363F569F /* Pods-OASIS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OASIS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OASIS/Pods-OASIS.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -194,6 +196,7 @@
 		5A4972A51DC66F50006479DA /* ValueObjects */ = {
 			isa = PBXGroup;
 			children = (
+				D12FFCE01DCB5490001B272F /* FBProfile.swift */,
 			);
 			name = ValueObjects;
 			sourceTree = "<group>";
@@ -595,6 +598,7 @@
 				5AF25CE81DC9B2E400CA07F8 /* MyPageEntranceViewController.swift in Sources */,
 				5A0051381DCB193D00F1632F /* RegistrationController.swift in Sources */,
 				5AF25CD61DC9B09300CA07F8 /* RegistrationUserViewController.swift in Sources */,
+				D12FFCE11DCB5490001B272F /* FBProfile.swift in Sources */,
 				5AD4ABD81DCA3622009CF1A5 /* SceneRouter.swift in Sources */,
 				5AF25D261DCA314C00CA07F8 /* NSObject+.swift in Sources */,
 				5AF25D221DCA2BE900CA07F8 /* ErrorHandlable.swift in Sources */,

--- a/OASIS/FBProfile.swift
+++ b/OASIS/FBProfile.swift
@@ -12,11 +12,11 @@ struct FBProfile: Decodable {
     let name: String
     let gender: String
     let id: String
-    let profile_img: String
+    let profileImage: String
     let education: [FBSchool]
 
     static func decode(_ e: Extractor) throws -> FBProfile {
-        return try FBProfile(name: e <| "name", gender: e <| "gender", id: e <| "id", profile_img: e <| ["picture","data","url"], education: e <|| "education")
+        return try FBProfile(name: e <| "name", gender: e <| "gender", id: e <| "id", profileImage: e <| ["picture","data","url"], education: e <|| "education")
     }
 }
 
@@ -24,7 +24,7 @@ struct FBSchool: Decodable {
     let name: String
     let type: String
     let concentration: [FBDepartment]?
-    
+
     static func decode(_ e: Extractor) throws -> FBSchool {
         return try FBSchool(name: e <| ["school","name"], type: e <| "type", concentration: e <||? "concentration")
     }

--- a/OASIS/FBProfile.swift
+++ b/OASIS/FBProfile.swift
@@ -1,0 +1,30 @@
+//
+//  FBProfile.swift
+//  OASIS
+//
+//  Created by Yuto Yazaki on 2016/11/03.
+//  Copyright © 2016年 othlotech. All rights reserved.
+//
+
+import Himotoki
+
+struct FBProfile: Decodable {
+    let name: String
+    let gender: String
+    let id: String
+    let education: [FBSchool]
+
+    static func decode(_ e: Extractor) throws -> FBProfile {
+        return try FBProfile(name: e <| "name", gender: e <| "gender", id: e <| "id", education: e <|| "education")
+    }
+}
+
+struct FBSchool: Decodable {
+    let name: String
+    let type: String
+    let concentration: String?
+    
+    static func decode(_ e: Extractor) throws -> FBSchool {
+        return try FBSchool(name: e <| ["school","name"], type: e <| "type", concentration: e <|? ["concentration","name"])
+    }
+}

--- a/OASIS/FBProfile.swift
+++ b/OASIS/FBProfile.swift
@@ -12,19 +12,28 @@ struct FBProfile: Decodable {
     let name: String
     let gender: String
     let id: String
+    let profile_img: String
     let education: [FBSchool]
 
     static func decode(_ e: Extractor) throws -> FBProfile {
-        return try FBProfile(name: e <| "name", gender: e <| "gender", id: e <| "id", education: e <|| "education")
+        return try FBProfile(name: e <| "name", gender: e <| "gender", id: e <| "id", profile_img: e <| ["picture","data","url"], education: e <|| "education")
     }
 }
 
 struct FBSchool: Decodable {
     let name: String
     let type: String
-    let concentration: String?
+    let concentration: [FBDepartment]?
     
     static func decode(_ e: Extractor) throws -> FBSchool {
-        return try FBSchool(name: e <| ["school","name"], type: e <| "type", concentration: e <|? ["concentration","name"])
+        return try FBSchool(name: e <| ["school","name"], type: e <| "type", concentration: e <||? "concentration")
+    }
+}
+
+struct FBDepartment: Decodable {
+    let name: String
+
+    static func decode(_ e: Extractor) throws -> FBDepartment {
+        return try FBDepartment(name: e <| "name")
     }
 }

--- a/OASIS/FBProfile.swift
+++ b/OASIS/FBProfile.swift
@@ -16,7 +16,7 @@ struct FBProfile: Decodable {
     let education: [FBSchool]
 
     static func decode(_ e: Extractor) throws -> FBProfile {
-        return try FBProfile(name: e <| "name", gender: e <| "gender", id: e <| "id", profileImage: e <| ["picture","data","url"], education: e <|| "education")
+        return try FBProfile(name: e <| "name", gender: e <| "gender", id: e <| "id", profileImage: e <| ["picture", "data", "url"], education: e <|| "education")
     }
 }
 
@@ -26,7 +26,7 @@ struct FBSchool: Decodable {
     let concentration: [FBDepartment]?
 
     static func decode(_ e: Extractor) throws -> FBSchool {
-        return try FBSchool(name: e <| ["school","name"], type: e <| "type", concentration: e <||? "concentration")
+        return try FBSchool(name: e <| ["school", "name"], type: e <| "type", concentration: e <||? "concentration")
     }
 }
 

--- a/OASIS/MatchingEntranceViewController.swift
+++ b/OASIS/MatchingEntranceViewController.swift
@@ -35,7 +35,6 @@ class MatchingEntranceViewController: ButtonBarPagerTabStripViewController, Stor
         settings.style.selectedBarHeight = 4
         settings.style.selectedBarBackgroundColor = UIColor.gray.withAlphaComponent(0.5)
 
-        
         self.buttonBarView.collectionViewLayout = UICollectionViewFlowLayout()
         self.buttonBarView.frame.size.height = 40
     }

--- a/OASIS/RegistrationEntranceViewController.swift
+++ b/OASIS/RegistrationEntranceViewController.swift
@@ -19,7 +19,7 @@ class RegistrationEntranceViewController: UIViewController, Storyboardable, Erro
     // MARK: - Action
     @IBAction private func loginBtnDidTap(_ sender: UIButton) {
         let manager = LoginManager()
-        manager.logIn([.publicProfile], viewController: self) { [weak self] result in
+        manager.logIn([.publicProfile, .custom("user_education_history")], viewController: self) { [weak self] result in
             switch result {
             case .success(_, _, let token):
                 self?.signIn(token: token)

--- a/OASIS/RegistrationTimeTableViewController.swift
+++ b/OASIS/RegistrationTimeTableViewController.swift
@@ -26,7 +26,7 @@ class RegistrationTimeTableViewController: UIViewController, Storyboardable {
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         collectionView.delegate = self
         collectionView.dataSource = self
     }
@@ -45,9 +45,9 @@ extension RegistrationTimeTableViewController: UICollectionViewDelegate {
         guard let cell = collectionView.cellForItem(at: indexPath) else { return }
 
         if cell.reuseIdentifier == emptyCellIdentifier {
-            
+
         } else {
-            
+
         }
 
         collectionView.reloadItems(at: [indexPath])

--- a/OASIS/RegistrationUserViewController.swift
+++ b/OASIS/RegistrationUserViewController.swift
@@ -29,7 +29,7 @@ class RegistrationUserViewController: UIViewController, Storyboardable, ErrorHan
 
     // MARK: - Private
     private func fetchUserProfile(token: AccessToken) {
-        let params: [String: Any] = ["fields":"email,name,picture.width(1000).height(1000),gender,education", "locale": "ja_JP"]
+        let params: [String: Any] = ["fields":"email,name,picture.width(300).height(300),gender,education", "locale": "ja_JP"]
         let graphRequest = GraphRequest(graphPath: "me", parameters: params, accessToken: token, httpMethod: .GET, apiVersion: .defaultVersion)
 
         // Facebook Graph APIからプロフィールを取得
@@ -40,12 +40,12 @@ class RegistrationUserViewController: UIViewController, Storyboardable, ErrorHan
                 break
             case .success(let graphResponse):
                 if let responseDictionary = graphResponse.dictionaryValue {
+                    let jsonData = try! JSONSerialization.data(withJSONObject: responseDictionary, options: .prettyPrinted)
+                    print(NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue))
                     let profile: FBProfile = try! decodeValue(responseDictionary) //エラー処理はちゃんとやろう。
-                    dump(profile)
                     self.setProfile(profile: profile)
                 }
             }
-            
         }
     }
 
@@ -53,7 +53,7 @@ class RegistrationUserViewController: UIViewController, Storyboardable, ErrorHan
         guard let user = FIRAuth.auth()?.currentUser else { return }
 
         // Firebase Realtime Databaseに突っ込む
-        let data = ["name": profile.name, "univ": profile.education.last!.name, "gender": profile.gender]
+        let data = ["name": profile.name, "univ": profile.education.last!.name, "gender": profile.gender, "profile_img": profile.profile_img, "department": profile.education.last?.concentration?.last?.name ?? ""]
         ref.child("users/\(user.uid)").setValue(data) { (error, ref) in
             if error != nil {
                 print(error)

--- a/OASIS/RegistrationUserViewController.swift
+++ b/OASIS/RegistrationUserViewController.swift
@@ -9,23 +9,12 @@
 import UIKit
 import Firebase
 import FacebookCore
+import Himotoki
 
 class RegistrationUserViewController: UIViewController, Storyboardable, ErrorHandlable {
 
     // MARK: - Property
     static let storyboardName = "RegistrationUser"
-//    struct UserProfileRequest: GraphRequestProtocol {
-//        let graphPath = "me"
-//        let parameters: [String : Any]? = [:]
-//        let accessToken: AccessToken?
-//        let httpMethod: GraphRequestHTTPMethod = .GET
-//        let apiVersion: GraphAPIVersion = .defaultVersion
-//
-//        init(token: String) {
-//            self.accessToken = AccessToken(authenticationToken: token)
-//        }
-//        
-//    }
 
     // MARK: - Action
     @IBAction private func submitBtnDidTap(_ sender: UIButton) {
@@ -33,7 +22,6 @@ class RegistrationUserViewController: UIViewController, Storyboardable, ErrorHan
 
         user.getTokenWithCompletion { (token, error) in
             guard let token = token else { return }
-            print(token)
             self.fetchUserProfile(token: AccessToken(authenticationToken: token))
         }
 //        let request = user.profileChangeRequest()
@@ -51,7 +39,10 @@ class RegistrationUserViewController: UIViewController, Storyboardable, ErrorHan
 
     // MARK: - Private
     private func fetchUserProfile(token: AccessToken) {
-        let graphRequest = GraphRequest(graphPath: "me", parameters: [:], accessToken: token, httpMethod: .GET, apiVersion: .defaultVersion)
+        let params: [String: Any] = ["fields":"email,name,picture.width(1000).height(1000),gender,education", "locale": "ja_JP"]
+        let graphRequest = GraphRequest(graphPath: "me", parameters: params, accessToken: token, httpMethod: .GET, apiVersion: .defaultVersion)
+
+        // Facebook Graph APIからプロフィールを取得
         graphRequest.start { (urlResponse, requestResult) in
             switch requestResult {
             case .failed(let error):
@@ -59,12 +50,11 @@ class RegistrationUserViewController: UIViewController, Storyboardable, ErrorHan
                 break
             case .success(let graphResponse):
                 if let responseDictionary = graphResponse.dictionaryValue {
-                    dump(responseDictionary)
+                    let profile: FBProfile = try! decodeValue(responseDictionary)
+                    dump(profile)
                 }
             }
             
         }
-//        let connection = GraphRequestConnection()
-//        connection.add(<#T##request: T##T#>, batchEntryName: <#T##String?#>, completion: <#T##(HTTPURLResponse?, GraphRequestResult<T>) -> Void?##(HTTPURLResponse?, GraphRequestResult<T>) -> Void?##(HTTPURLResponse?, GraphRequestResult<T>) -> Void#>)
     }
 }

--- a/OASIS/RegistrationUserViewController.swift
+++ b/OASIS/RegistrationUserViewController.swift
@@ -8,26 +8,63 @@
 
 import UIKit
 import Firebase
+import FacebookCore
 
 class RegistrationUserViewController: UIViewController, Storyboardable, ErrorHandlable {
 
     // MARK: - Property
     static let storyboardName = "RegistrationUser"
+//    struct UserProfileRequest: GraphRequestProtocol {
+//        let graphPath = "me"
+//        let parameters: [String : Any]? = [:]
+//        let accessToken: AccessToken?
+//        let httpMethod: GraphRequestHTTPMethod = .GET
+//        let apiVersion: GraphAPIVersion = .defaultVersion
+//
+//        init(token: String) {
+//            self.accessToken = AccessToken(authenticationToken: token)
+//        }
+//        
+//    }
 
     // MARK: - Action
     @IBAction private func submitBtnDidTap(_ sender: UIButton) {
         guard let user = FIRAuth.auth()?.currentUser else { return }
 
-        let request = user.profileChangeRequest()
-        request.displayName = "ヒデちゃん"
-        request.photoURL = URL(string: "http://www.othlo.tech/images/members/hide.png")
-        request.commitChanges { error in
-            if let error = error {
-                self.handle(error: error)
-            } else {
-                let next = RegistrationTimeTableViewController.makeFromStoryboard()
-                self.navigationController?.pushViewController(next, animated: true)
-            }
+        user.getTokenWithCompletion { (token, error) in
+            guard let token = token else { return }
+            print(token)
+            self.fetchUserProfile(token: AccessToken(authenticationToken: token))
         }
+//        let request = user.profileChangeRequest()
+//        request.displayName = "ヒデちゃん"
+//        request.photoURL = URL(string: "http://www.othlo.tech/images/members/hide.png")
+//        request.commitChanges { error in
+//            if let error = error {
+//                self.handle(error: error)
+//            } else {
+//                let next = RegistrationTimeTableViewController.makeFromStoryboard()
+//                self.navigationController?.pushViewController(next, animated: true)
+//            }
+//        }
+    }
+
+    // MARK: - Private
+    private func fetchUserProfile(token: AccessToken) {
+        let graphRequest = GraphRequest(graphPath: "me", parameters: [:], accessToken: token, httpMethod: .GET, apiVersion: .defaultVersion)
+        graphRequest.start { (urlResponse, requestResult) in
+            switch requestResult {
+            case .failed(let error):
+                print("error in graph request:", error)
+                break
+            case .success(let graphResponse):
+                if let responseDictionary = graphResponse.dictionaryValue {
+                    dump(responseDictionary)
+                }
+            }
+            
+        }
+//        let connection = GraphRequestConnection()
+//        connection.add(<#T##request: T##T#>, batchEntryName: <#T##String?#>, completion: <#T##(HTTPURLResponse?, GraphRequestResult<T>) -> Void?##(HTTPURLResponse?, GraphRequestResult<T>) -> Void?##(HTTPURLResponse?, GraphRequestResult<T>) -> Void#>)
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -15,6 +15,7 @@ target 'OASIS' do
 
     # util
     pod 'SwiftTask', git: 'https://github.com/ReactKit/SwiftTask.git', branch: 'swift/3.0'
+    pod 'Himotoki', '~> 3.0'
 
     # view
     pod 'Kingfisher', '~> 3.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -67,6 +67,7 @@ PODS:
     - GoogleToolboxForMac/NSString+URLArguments (= 2.1.0)
   - GoogleToolboxForMac/NSString+URLArguments (2.1.0)
   - GTMSessionFetcher/Core (1.1.7)
+  - Himotoki (3.0.0)
   - Kingfisher (3.1.4)
   - Spring (1.0.3)
   - SwiftTask (5.0.0)
@@ -79,6 +80,7 @@ DEPENDENCIES:
   - Firebase/Core
   - Firebase/Database
   - Firebase/Messaging
+  - Himotoki (~> 3.0)
   - Kingfisher (~> 3.0)
   - Spring (from `https://github.com/MengTo/Spring.git`, branch `swift3`)
   - SwiftTask (from `https://github.com/ReactKit/SwiftTask.git`, branch `swift/3.0`)
@@ -117,11 +119,12 @@ SPEC CHECKSUMS:
   GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
   GoogleToolboxForMac: 2b2596cbb7186865e98cadf2b1e262d851c2b168
   GTMSessionFetcher: a1f8ed39e4fe21c68957daed472c7afbcdf29166
+  Himotoki: df74b01035e86e021b7b04a15b033a7fd189b84f
   Kingfisher: 6c67e3e57f2d81a9cfdfa25052cd86f33ceac9bb
   Spring: 3f02b5dc3308572ef177b3cad0fa7bbc4b0706f7
   SwiftTask: 7fcd92f8ac16876e82c0e4ced0cea7e028456b6b
   XLPagerTabStrip: c46e802a8dcac29edbcea573de8fe920e052455b
 
-PODFILE CHECKSUM: 79b139cafac166fa7fc0d673e13672c3aec317bb
+PODFILE CHECKSUM: db53f3172643020069afa0e8f687e3209e9e75a8
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
### 変更内容

- [x] Graph APIの返り値をHimotokiで紐解く
- [x] そのうちSwiftTaskで実装する
- [x] Firebaseの`/users/{ui}`に突っ込む
- [x] FBアクセスのパーミッション`"user_education_history"`はリリースのときにレビュー対象なので注意

### スクリーンショット
|4|4.7|5.5|
|---|---|---|
||||

### 関連

UIは別プルリクでやります！